### PR TITLE
Changed CI for building Universal Binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - run: python -m pip install --upgrade meson ninja
       - run: meson setup build/
       - run: meson compile -C build
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         with:
           name: krkrrel-ubuntu
           path: build/krkrrel
@@ -66,7 +66,7 @@ jobs:
       - run: python -m pip install --upgrade meson ninja
       - run: meson setup build/ --cross-file ./external/meson_toolchains/mingw32_meson.ini
       - run: meson compile -C build
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         with:
           name: krkrrel-win32
           path: build/krkrrel.exe
@@ -90,7 +90,7 @@ jobs:
         env:
            "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64"
       - run: meson compile -C build
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         with:
           name: krkrrel-macos
           path: build/krkrrel
@@ -101,17 +101,17 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
     - name: Download ubuntu artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: krkrrel-ubuntu
 
     - name: Download win32 artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: krkrrel-win32
 
     - name: Download macos artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: krkrrel-macos
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
       - uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: '3.x'
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: '3.x'
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip
@@ -101,17 +101,17 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
     - name: Download ubuntu artifact
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v2
       with:
         name: krkrrel-ubuntu
 
     - name: Download win32 artifact
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v2
       with:
         name: krkrrel-win32
 
     - name: Download macos artifact
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v2
       with:
         name: krkrrel-macos
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           name: krkrrel-win32
           path: build/krkrrel.exe
   build-macos:
-    runs-on: macos-10.15
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v2
         with:
@@ -87,6 +87,8 @@ jobs:
             ${{ runner.os }}-pip
       - run: python -m pip install --upgrade meson ninja
       - run: meson setup build/
+        env:
+           "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64"
       - run: meson compile -C build
       - uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip
       - run: python -m pip install --upgrade meson ninja
-      - run: meson setup build/
-        env:
-           "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64"
+      - run: meson setup build/ --cross-file cross-file-macos-universal.txt
       - run: meson compile -C build
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,12 +115,9 @@ jobs:
       with:
         name: krkrrel-macos
 
-    - name: List downloaded files
-    　　　　run: |
-        ls -la
-
     - name: Prepare artifacts for release
       run: |
+        pwd;find . | sort | sed '1d;s/^\.//;s/\/\([^/]*\)$/|--\1/;s/\/[^/|]*/|  /g'
         7z a -tzip krkrrel-ubuntu.zip /home/runner/work/krkrrel-ng/krkrrel-ng/krkrrel-ubuntu/*
         7z a -tzip krkrrel-win32.zip /home/runner/work/krkrrel-ng/krkrrel-ng/krkrrel-win32/*
         7z a -tzip krkrrel-macos.zip /home/runner/work/krkrrel-ng/krkrrel-ng/krkrrel-macos/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,23 +104,26 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: krkrrel-ubuntu
+        path: krkrrel-ubuntu
 
     - name: Download win32 artifact
       uses: actions/download-artifact@v4
       with:
         name: krkrrel-win32
+        path: krkrrel-win32
 
     - name: Download macos artifact
       uses: actions/download-artifact@v4
       with:
         name: krkrrel-macos
+        path: krkrrel-macos
 
     - name: Prepare artifacts for release
       run: |
         pwd;find . | sort | sed '1d;s/^\.//;s/\/\([^/]*\)$/|--\1/;s/\/[^/|]*/|  /g'
-        7z a -tzip krkrrel-ubuntu.zip /home/runner/work/krkrrel-ng/krkrrel-ng/krkrrel-ubuntu/*
-        7z a -tzip krkrrel-win32.zip /home/runner/work/krkrrel-ng/krkrrel-ng/krkrrel-win32/*
-        7z a -tzip krkrrel-macos.zip /home/runner/work/krkrrel-ng/krkrrel-ng/krkrrel-macos/*
+        7z a -tzip krkrrel-ubuntu.zip krkrrel-ubuntu/*
+        7z a -tzip krkrrel-win32.zip krkrrel-win32/*
+        7z a -tzip krkrrel-macos.zip krkrrel-macos/*
 
     - name: Create prerelease
       if: github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,10 @@ jobs:
       with:
         name: krkrrel-macos
 
+    - name: List downloaded files
+    　　　　run: |
+        ls -la
+
     - name: Prepare artifacts for release
       run: |
         7z a -tzip krkrrel-ubuntu.zip /home/runner/work/krkrrel-ng/krkrrel-ng/krkrrel-ubuntu/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,9 @@ jobs:
 
     - name: Prepare artifacts for release
       run: |
-        7z a -tzip krkrrel-ubuntu.zip krkrrel-ubuntu/*
-        7z a -tzip krkrrel-win32.zip krkrrel-win32/*
-        7z a -tzip krkrrel-macos.zip krkrrel-macos/*
+        7z a -tzip krkrrel-ubuntu.zip /home/runner/work/krkrrel-ng/krkrrel-ng/krkrrel-ubuntu/*
+        7z a -tzip krkrrel-win32.zip /home/runner/work/krkrrel-ng/krkrrel-ng/krkrrel-win32/*
+        7z a -tzip krkrrel-macos.zip /home/runner/work/krkrrel-ng/krkrrel-ng/krkrrel-macos/*
 
     - name: Create prerelease
       if: github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
     - name: Prepare artifacts for release
       run: |
         pwd;find . | sort | sed '1d;s/^\.//;s/\/\([^/]*\)$/|--\1/;s/\/[^/|]*/|  /g'
+        chmod +x krkrrel-ubuntu/krkrrel
+        chmod +x krkrrel-macos/krkrrel
         7z a -tzip krkrrel-ubuntu.zip krkrrel-ubuntu/*
         7z a -tzip krkrrel-win32.zip krkrrel-win32/*
         7z a -tzip krkrrel-macos.zip krkrrel-macos/*

--- a/cross-file-macos-universal.txt
+++ b/cross-file-macos-universal.txt
@@ -1,0 +1,14 @@
+[host_machine]
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+system = 'darwin'
+endian = 'little'
+
+[binaries]
+c = 'cc'
+cpp = 'c++'
+
+[built-in options]
+c_args = ['-arch', 'arm64', '-arch', 'x86_64', '-mmacosx-version-min=10.7']
+cpp_args = ['-arch', 'arm64', '-arch', 'x86_64', '-stdlib=libc++', '-mmacosx-version-min=10.7']
+cpp_link_args = ['-arch', 'arm64', '-arch', 'x86_64', '-stdlib=libc++', '-mmacosx-version-min=10.7']


### PR DESCRIPTION
Changed for running on Apple Silicon without Rosetta 2.
I have confirmed that it runs on an M1 Macbook Air and is a universal binary.

<img width="1006" alt="image" src="https://github.com/krkrsdl2/krkrrel-ng/assets/58556570/c3e98132-6253-4f74-b6bf-03fc32f86c46">
